### PR TITLE
Delete alumni roles along with alumni groups

### DIFF
--- a/app/models/jubla/group.rb
+++ b/app/models/jubla/group.rb
@@ -41,7 +41,10 @@ module Jubla::Group
     private
 
     def delete_alumni_groups
-      children.where(type: ALUMNI_GROUPS_CLASSES).delete_all
+      alumni_groups = children.where(type: ALUMNI_GROUPS_CLASSES)
+      # Hard delete alumni roles because they cannot be soft deleted
+      Role.with_deleted.where(group_id: alumni_groups.select(:id)).delete_all
+      alumni_groups.delete_all
     end
 
   end

--- a/app/models/jubla/group.rb
+++ b/app/models/jubla/group.rb
@@ -42,7 +42,7 @@ module Jubla::Group
 
     def delete_alumni_groups
       alumni_groups = children.where(type: ALUMNI_GROUPS_CLASSES)
-      # Hard delete alumni roles because they cannot be soft deleted
+      # Hard delete alumni roles because the alumni groups are also hard deleted
       Role.with_deleted.where(group_id: alumni_groups.select(:id)).delete_all
       alumni_groups.delete_all
     end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -99,6 +99,17 @@ describe Group do
         expect(Group.without_deleted.where(id: alumnus_group2.id)).not_to exist
         expect(Group.without_deleted.where(id: alumnus_group3.id)).not_to exist
       end
+
+      it 'deletes all alumnus roles when deleting an alumnus group via its layer' do
+        group = Group::Region.all.first
+        group.children.delete_all
+        alumnus_group = Group::RegionalAlumnusGroup.create(name: 'test_group', parent_id: group.id)
+        Role.create(group: alumnus_group, person: people(:bottom_member))
+
+        expect(Role.with_deleted.where.not(group_id: Group.with_deleted.select(:id)).count).to be 0
+
+        expect { group.destroy }.not_to change { Role.with_deleted.where.not(group_id: Group.with_deleted.select(:id)).count }
+      end
     end
   end
 


### PR DESCRIPTION
This was apparently forgotten when hitobito/hitobito#369 was implemented. It led to roles with group_id that referenced nonexisting groups, which in turn led to a lot of problems in other places in the application (mostly `undefined method 'xyz' on nil`)