### PR TITLE
Rails 6.1 for the wagon

### DIFF
--- a/app/domain/jubla/role/alumnus_manager.rb
+++ b/app/domain/jubla/role/alumnus_manager.rb
@@ -51,7 +51,7 @@ module Jubla::Role
       person
         .roles
         .joins(:group)
-        .where(group: group, type: group.alumnus_class)
+        .where(group: group, type: group.alumnus_class.name)
         .destroy_all
     end
 

--- a/app/mailers/census_mailer.rb
+++ b/app/mailers/census_mailer.rb
@@ -1,21 +1,21 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 class CensusMailer < ApplicationMailer
 
-  CONTENT_INVITATION = 'census_invitation'.freeze
-  CONTENT_REMINDER   = 'census_reminder'.freeze
+  CONTENT_INVITATION = 'census_invitation'
+  CONTENT_REMINDER   = 'census_reminder'
 
   def reminder(sender, census, recipients, flock, state_agency)
     values = {
-      'due-date'        => due_date(census),
+      'due-date' => due_date(census),
       'recipient-names' => recipients.collect(&:first_name).join(', '),
       'contact-address' => contact_address(state_agency),
-      'census-url'      => link_to(census_url(flock))
+      'census-url' => link_to(census_url(flock))
     }
     custom_content_mail(recipients, CONTENT_REMINDER, values, with_personal_sender(sender))
   end

--- a/app/models/jubla/role.rb
+++ b/app/models/jubla/role.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -120,7 +120,7 @@ module Jubla::Role
   end
 
   def set_person_origins
-    person.update_columns(GroupOriginator.new(person).to_h)
+    person.update_columns(GroupOriginator.new(person).to_h) # rubocop:disable Rails/SkipsModelValidations intentionally, because it's called from an after_save hook
   end
 
   def alumnus_manager_create
@@ -140,7 +140,9 @@ module Jubla::Role
   end
 
   def alumnus_manager
-    @alumnus_manager ||= Jubla::Role::AlumnusManager.new(self, skip_alumnus_callback)
+    @alumnus_manager ||= Jubla::Role::AlumnusManager.new(
+      self, skip_alumnus_callback: skip_alumnus_callback
+    )
   end
 
 end

--- a/app/views/event/qualifications/index.html.haml
+++ b/app/views/event/qualifications/index.html.haml
@@ -3,13 +3,20 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
+- title event.to_s
+
 - if event.qualification_possible?
-  - # This renders the file from core with a deprecation warning, not sure how to work around
-  = render file: Rails.root.join('app', 'views', 'event', 'qualifications', 'index')
+  -# copied from [hitobito_core]/app/views/event/qualifications/index.html.haml
+  = form_tag(group_event_qualifications_path(@group, @event), method: :put) do
+
+    = render 'people'
+
+    .btn-group
+      = button_tag(t('event.qualifications.index.save'),
+                   class: 'btn btn-primary',
+                   data: { disable_with: t('event.qualifications.index.save') })
 
 - else
-  - title event.to_s
-
   %p Im aktuellen Kurs Status können die Qualifikationen nicht mehr bearbeitet werden.
 
   = render 'people'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,13 +21,17 @@ application:
   languages:
     de: Deutsch
 
+<% mail_domain = ENV['RAILS_MAIL_DOMAIN'].presence ||
+                 ENV['RAILS_HOST_NAME'].presence ||
+                 'localhost' %>
+
 email:
   # Sender for all emails sent by the application
-  sender: <%= "jubla.db <noreply@#{ENV['RAILS_HOST_NAME'].presence || 'localhost'}>" %>
+  sender: <%= "jubla.db <noreply@#{mail_domain}>" %>
 
   # If mass emails are sent, this recipient is used in the to field,
   # while the actual recipients go in the bcc field.
-  mass_recipient: <%= "jubla.db <noreply@#{ENV['RAILS_HOST_NAME'].presence || 'localhost'}>" %>
+  mass_recipient: <%= "jubla.db <noreply@#{mail_domain}>" %>
 
 root_email: jubla@puzzle.ch
 


### PR DESCRIPTION
This PR contains 2 changes needed for Rails 6.1:

- the alumnus-manager needs to pass the Role-type by name, not as a class.
- the template cannot be read from the core anymore, therefore it needed to be copied

The other changes make the specs a bit more resilient and adaptable.

See hitobito/hitobito#1390, hitobito/hitobito#1400