### PR TITLE
Anpassung views.de.yml alternative_dates_info

### DIFF
--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -23,6 +23,8 @@ de:
       events:
         explanation: Angezeigt werden hier Anlässe deiner Schar, deiner Regions- und Kantonsleitung, der Bundesebene, sowie von Gruppen bei welchen du Mitglied bist.
     participations:
+      application_fields:
+        alternative_dates_info: 'Melde dich verbindlich für Alternativen an, falls du von der Kursverwaltung für den bestmöglichen Kurs zugeteilt werden darfst.'
       print:
         heading_event/camp: Lageranmeldung
         requirements_for_event_camp: Voraussetzungen für das Lager


### PR DESCRIPTION
Ziel: Text zu Ausweichdaten bei Kursanmeldung anpassen
Aus: (alternative_dates_info)
Bitte gib weitere Kurse an, welche dir gehen würden.
Wird: 
Melde dich verbindlich für Alternativen an, falls du von der Kursverwaltung für den bestmöglichen Kurs zugeteilt werden darfst. 


Zu diesem pull request gibt es ein Support-Ticket.