### PR TITLE
Anpassungen von Rollen: FG-Mitgleider :contact_data-Flag entfernen

### DIFF
--- a/app/models/group/professional_group.rb
+++ b/app/models/group/professional_group.rb
@@ -35,7 +35,7 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -47,7 +47,7 @@ class Group::ProfessionalGroup < Group
   end
 
   class Member < Jubla::Role::Member
-    self.permissions = [:contact_data, :group_read]
+    self.permissions = [:group_read]
   end
 
 end

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -255,7 +255,7 @@ describe PersonAbility do
   end
 
   describe :contact_data do
-    let(:role) { Fabricate(Group::StateBoard::Member.name.to_sym, group: groups(:be_board)) }
+    let(:role) { Fabricate(Group::StateBoard::Leader.name.to_sym, group: groups(:be_board)) }
 
     it 'may view details of himself' do
       is_expected.to be_able_to(:show_full, role.person.reload)
@@ -294,7 +294,7 @@ describe PersonAbility do
     end
 
     it 'may show any public role in same layer' do
-      other = Fabricate(Group::StateProfessionalGroup::Member.name.to_sym, group: groups(:be_security))
+      other = Fabricate(Group::StateProfessionalGroup::Leader.name.to_sym, group: groups(:be_security))
       is_expected.to be_able_to(:show, other.person.reload)
     end
 


### PR DESCRIPTION
Mitglieder von Fachgruppen haben aktuell Kontaktrelevanz.
Da sie keine “Leitende” oder "Verantwortliche" Funktion haben (Scharleitung/Präsident/etc.) und auch nicht in einer Ebene/Gruppe mit “Leitender” Aufgabe sind (Kantonsleitung/Regionalleitung) ist nicht gerechtfertigt/schlüssig, dass sie Kontaktrelevanz besitzen.

Aspekte

Jubla Datenschutz https://jubladb-handbuch.readthedocs.io/de/latest/datenschutz.html
Wer sieht meine Daten https://jubladb-handbuch.readthedocs.io/de/latest/anleitung.html#wer-sieht-meine-daten

Definition of Done

Die Berechtigung(en) :contact_data für die Rolle Mitglied in der Ebene/Gruppe Fachgruppe ist entfernt.