### PR TITLE
Definitive Anpassung gemäss Vorgabe Kursadmin

### DIFF
--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -24,7 +24,7 @@ de:
         explanation: Angezeigt werden hier Anlässe deiner Schar, deiner Regions- und Kantonsleitung, der Bundesebene, sowie von Gruppen bei welchen du Mitglied bist.
     participations:
       application_fields:
-        alternative_dates_info: 'Melde dich verbindlich für Alternativen an, falls du von der Kursverwaltung für den bestmöglichen Kurs zugeteilt werden darfst.'
+        alternative_dates_info: 'Wenn du möchtest, kannst du hier ein bis zwei Alternativkurse vermerken.'
       print:
         heading_event/camp: Lageranmeldung
         requirements_for_event_camp: Voraussetzungen für das Lager


### PR DESCRIPTION

Wir machen eine Anpassung (der Anpassung)

Interne Notiz: Der Text ist nun gemäss eigener Definition der Kursadministration. Die Kursverwaltung soll jede Anmeldung manuell prüfen und eine Zuteilung in der Priorität 2/3 erst nach erfolgreicher Bestätigung durchführen. So ist auch sichergestellt, dass für die Zuteilung eine Bestätigung vorliegt und diese bewusst durch die Kursverwaltung durchgeführt wurde. Ohne diese (manuelle) Bestätigung ist nicht nachvollziehbar, dass sich die angemeldete Person auch für weitere Kurse (gemäss Prio) angemeldet hat.


