### PR TITLE
Custom Text for Table Show qualified in person history events (Update…

### DIFF
--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -78,3 +78,14 @@ de:
 
   navigation:
     camps: Lager
+
+  history:
+      events:
+        event_label: "Name / Gruppe"
+      index:
+        inactive_roles_title: "Ehemalige Rollen (Inaktiv)"
+        qualified: "Qualifiziert"
+        not_qualified: "Beteiligt"
+        training_days:
+          one: "%{count} Ausbildungstag"
+          other: "%{count} Ausbildungstage"


### PR DESCRIPTION
… views.de.yml)

In response to the customization of “Show qualified in person history events #2540” 
 ( https://github.com/hitobito/hitobito/pull/2540 ), we would like to choose our own labels for the qualifications. 

Rationale and background:
- We would like to explicitly avoid the terms “passing” and “failing” in the context of the qualification as different criteria from attendance to mapping in the NDS influence the qualification
- A person who is merely “involved”, such as the camp kitchen or the coach, should not be emotionally confused by the technical term “not passed”.  (The option “not_qualified” is technically valid for all statuses that are not “qualified”)
- We are aware that the designation should and must continue to function in the sense of qualification (feature qualifications).

A support ticket for billing/support is created for the pull. Please check whether it makes sense and, if necessary, unsupport it. In case of forgotten dependencies or excessive complexity, reject and refer to a regular story.