### PR TITLE
hitobito_jubla#78: Verwalter*innen bei Anmeldung anzeigen

### DIFF
--- a/app/domain/jubla/export/pdf/participation.rb
+++ b/app/domain/jubla/export/pdf/participation.rb
@@ -23,6 +23,7 @@ module Jubla::Export::Pdf
           super
           labeled_attr(person, :originating_flock)
           labeled_attr(person, :originating_state)
+          render_people_managers
         end
 
         def person_attributes
@@ -32,6 +33,18 @@ module Jubla::Export::Pdf
         def address_details
           zip_code, town = super
           [zip_code, [town, person.canton].compact_blank.join(", ")]
+        end
+
+        def render_people_managers
+          return unless person.people_managers.any?
+
+          with_settings(font_size: 7) do
+            move_down_line
+            text PeopleManager.model_name.human(count: person.people_managers.count), style: :bold
+            person.people_managers&.each do |manager|
+              text "#{manager.manager}: #{[manager.email, manager.phone_number&.number].compact_blank.join(', ')}"
+            end
+          end
         end
       end
 

--- a/app/domain/jubla/export/pdf/participation.rb
+++ b/app/domain/jubla/export/pdf/participation.rb
@@ -42,7 +42,7 @@ module Jubla::Export::Pdf
             move_down_line
             text PeopleManager.model_name.human(count: person.people_managers.count), style: :bold
             person.people_managers&.each do |manager|
-              text "#{manager.manager}: #{[manager.email, manager.phone_number&.number].compact_blank.join(', ')}"
+              text "#{manager.manager}: #{[manager.email, manager.phone_number&.number].compact_blank.join(", ")}"
             end
           end
         end

--- a/spec/domain/export/pdf/participation_spec.rb
+++ b/spec/domain/export/pdf/participation_spec.rb
@@ -1,0 +1,30 @@
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Export::Pdf::Participation do
+  include PdfHelpers
+
+  let(:participation) { event_participations(:top_participant) }
+  let!(:managers) do
+    2.times.map do
+      Fabricate(:person).tap do |manager|
+        manager.phone_numbers.create(number: "+41 44 123 45 57", label: "Privat")
+        participation.person.managers << manager
+      end
+    end
+  end
+  subject(:pdf) { described_class.render(participation) }
+
+    it "renders with all managers" do
+      expect(participation.person.managers).to contain_exactly(*managers)
+      text = PDF::Inspector::Text.analyze(pdf).show_text.join(' ')
+      expect(text).to include(PeopleManager.model_name.human(count: 1))
+      managers.each do |manager|
+        expect(text).to include("#{manager}: #{manager.email}, #{manager.phone_numbers.first.number}")
+      end
+    end
+end


### PR DESCRIPTION
refs #78 

muss mit [hitobito_youth#84](https://github.com/hitobito/hitobito_youth/pull/84) gemerged werden