### PR TITLE
NEJB: Prevent previous alumni-logic in new groups

### DIFF
--- a/app/models/group/alumnus_group.rb
+++ b/app/models/group/alumnus_group.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Ehemalige
-class Group::AlumnusGroup < Group
+class Group::AlumnusGroup < JublaGroup
   children Group::AlumnusGroup
 
   # Duplicate class attribute to customize it just for AlumnusGroups

--- a/app/models/group/child_group.rb
+++ b/app/models/group/child_group.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Kindergruppe
-class Group::ChildGroup < Group
+class Group::ChildGroup < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full]
   end

--- a/app/models/group/federal_board.rb
+++ b/app/models/group/federal_board.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Bundesleitung
-class Group::FederalBoard < Group
+class Group::FederalBoard < JublaGroup
   class Member < Jubla::Role::Member
     self.permissions = [:admin, :layer_and_below_full, :contact_data]
 

--- a/app/models/group/federation.rb
+++ b/app/models/group/federation.rb
@@ -42,7 +42,7 @@
 #
 
 # Ebene Bund
-class Group::Federation < Group
+class Group::Federation < JublaGroup
   self.layer = true
   self.default_children = [Group::FederalBoard, Group::OrganizationBoard,
     Group::FederalAlumnusGroup]

--- a/app/models/group/flock.rb
+++ b/app/models/group/flock.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Ebene Schar
-class Group::Flock < Group
+class Group::Flock < JublaGroup
   include RestrictedRole
 
   self.layer = true

--- a/app/models/group/kanton_ehemaligenverein.rb
+++ b/app/models/group/kanton_ehemaligenverein.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::KantonEhemaligenverein < ::Group
+class Group::KantonEhemaligenverein < NejbGroup
   ### ROLES
 
   class Leader < ::NejbRole

--- a/app/models/group/nejb.rb
+++ b/app/models/group/nejb.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::Nejb < ::Group
+class Group::Nejb < NejbGroup
   self.layer = true
   children Group::NejbBundesleitung,
     Group::NetzwerkEhemaligeJungwachtBlauring,

--- a/app/models/group/nejb_bundesleitung.rb
+++ b/app/models/group/nejb_bundesleitung.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::NejbBundesleitung < ::Group
+class Group::NejbBundesleitung < NejbGroup
   class GroupAdmin < ::NejbRole
     self.permissions = [:admin, :layer_and_below_full, :contact_data]
   end

--- a/app/models/group/nejb_kanton.rb
+++ b/app/models/group/nejb_kanton.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::NejbKanton < ::Group
+class Group::NejbKanton < NejbGroup
   children Group::KantonEhemaligenverein, Group::NejbRegion
   self.layer = true
 

--- a/app/models/group/nejb_region.rb
+++ b/app/models/group/nejb_region.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::NejbRegion < ::Group
+class Group::NejbRegion < NejbGroup
   children Group::RegionEhemaligenverein, Group::NejbSchar
   self.layer = true
 

--- a/app/models/group/nejb_schar.rb
+++ b/app/models/group/nejb_schar.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::NejbSchar < ::Group
+class Group::NejbSchar < NejbGroup
   self.layer = true
 
   ### ROLES

--- a/app/models/group/nejb_simple_group.rb
+++ b/app/models/group/nejb_simple_group.rb
@@ -41,24 +41,24 @@
 
 # Einfache Gruppe für Alumni, aber ohne Alumni-Magic, kann überall im NEJB-Baum angehängt werden.
 class Group::NejbSimpleGroup < NejbGroup
-  class Leader < Role
+  class Leader < NejbRole
     self.permissions = [:group_full]
   end
 
-  class Member < Role
+  class Member < NejbRole
     self.permissions = [:group_read]
   end
 
-  class GroupAdmin < Role
+  class GroupAdmin < NejbRole
   end
 
-  class External < Role
+  class External < NejbRole
     self.permissions = []
     self.visible_from_above = false
     self.kind = :external
   end
 
-  class DispatchAddress < Role
+  class DispatchAddress < NejbRole
   end
 
   roles Leader, Member, GroupAdmin, External, DispatchAddress

--- a/app/models/group/nejb_simple_group.rb
+++ b/app/models/group/nejb_simple_group.rb
@@ -1,0 +1,65 @@
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+# == Schema Information
+#
+# Table name: groups
+#
+#  id                          :integer          not null, primary key
+#  parent_id                   :integer
+#  lft                         :integer
+#  rgt                         :integer
+#  name                        :string(255)      not null
+#  short_name                  :string(31)
+#  type                        :string(255)      not null
+#  email                       :string(255)
+#  address                     :string(1024)
+#  zip_code                    :integer
+#  town                        :string(255)
+#  country                     :string(255)
+#  contact_id                  :integer
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  deleted_at                  :datetime
+#  layer_group_id              :integer
+#  creator_id                  :integer
+#  updater_id                  :integer
+#  deleter_id                  :integer
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  bank_account                :string(255)
+#  jubla_liability_insurance   :boolean          default(FALSE), not null
+#  jubla_full_coverage         :boolean          default(FALSE), not null
+#  parish                      :string(255)
+#  kind                        :string(255)
+#  unsexed                     :boolean          default(FALSE), not null
+#  clairongarde                :boolean          default(FALSE), not null
+#  founding_year               :integer
+#  jubla_property_insurance    :boolean          default(FALSE), not null
+#
+
+# Einfache Gruppe für Alumni, aber ohne Alumni-Magic, kann überall im NEJB-Baum angehängt werden.
+class Group::NejbSimpleGroup < NejbGroup
+  class Leader < Role
+    self.permissions = [:group_full]
+  end
+
+  class Member < Role
+    self.permissions = [:group_read]
+  end
+
+  class GroupAdmin < Role
+  end
+
+  class External < Role
+    self.permissions = []
+    self.visible_from_above = false
+    self.kind = :external
+  end
+
+  class DispatchAddress < Role
+  end
+
+  roles Leader, Member, GroupAdmin, External, DispatchAddress
+end

--- a/app/models/group/netzwerk_ehemalige_jungwacht_blauring.rb
+++ b/app/models/group/netzwerk_ehemalige_jungwacht_blauring.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::NetzwerkEhemaligeJungwachtBlauring < ::Group
+class Group::NetzwerkEhemaligeJungwachtBlauring < NejbGroup
   ### ROLES
 
   class Leader < ::NejbRole

--- a/app/models/group/organization_board.rb
+++ b/app/models/group/organization_board.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Verbandsleitung
-class Group::OrganizationBoard < Group
+class Group::OrganizationBoard < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full, :contact_data]
   end

--- a/app/models/group/professional_group.rb
+++ b/app/models/group/professional_group.rb
@@ -42,7 +42,7 @@
 #
 
 # Abstract professional group (Fachgruppe)
-class Group::ProfessionalGroup < Group
+class Group::ProfessionalGroup < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full, :contact_data]
   end

--- a/app/models/group/region.rb
+++ b/app/models/group/region.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Ebene Region
-class Group::Region < Group
+class Group::Region < JublaGroup
   self.layer = true
   self.default_children = [Group::RegionalBoard, Group::RegionalAlumnusGroup]
 

--- a/app/models/group/region_ehemaligenverein.rb
+++ b/app/models/group/region_ehemaligenverein.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::RegionEhemaligenverein < ::Group
+class Group::RegionEhemaligenverein < NejbGroup
   ### ROLES
 
   class Leader < ::NejbRole

--- a/app/models/group/regional_board.rb
+++ b/app/models/group/regional_board.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Regionalleitung
-class Group::RegionalBoard < Group
+class Group::RegionalBoard < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:layer_and_below_full, :contact_data]
   end

--- a/app/models/group/root.rb
+++ b/app/models/group/root.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
-class Group::Root < ::Group
+class Group::Root < Group
   self.layer = true
   self.event_types = []
 

--- a/app/models/group/simple_group.rb
+++ b/app/models/group/simple_group.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Einfache Gruppe, kann überall angehängt werden.
-class Group::SimpleGroup < Group
+class Group::SimpleGroup < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full]
   end

--- a/app/models/group/state.rb
+++ b/app/models/group/state.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -40,7 +40,7 @@
 #
 
 # Ebene Kanton
-class Group::State < Group
+class Group::State < JublaGroup
   self.layer = true
   self.default_children = [Group::StateAgency, Group::StateBoard, Group::StateAlumnusGroup]
   self.contact_group_type = Group::StateAgency

--- a/app/models/group/state_agency.rb
+++ b/app/models/group/state_agency.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Arbeitsstelle AST
-class Group::StateAgency < Group
+class Group::StateAgency < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:layer_and_below_full, :contact_data]
   end

--- a/app/models/group/state_board.rb
+++ b/app/models/group/state_board.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Kantonsvorstand
-class Group::StateBoard < Group
+class Group::StateBoard < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full, :layer_and_below_read, :contact_data]
   end

--- a/app/models/group/work_group.rb
+++ b/app/models/group/work_group.rb
@@ -34,13 +34,13 @@
 #  jubla_property_insurance    :boolean          default(FALSE), not null
 #
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
 
 # Abstract Work Group
-class Group::WorkGroup < Group
+class Group::WorkGroup < JublaGroup
   class Leader < Jubla::Role::Leader
     self.permissions = [:group_full, :contact_data]
   end

--- a/app/models/jubla/group.rb
+++ b/app/models/jubla/group.rb
@@ -31,9 +31,6 @@ module Jubla::Group
 
     has_many :course_conditions, class_name: "::Event::Course::Condition", dependent: :destroy
 
-    # define global children
-    children Group::SimpleGroup
-
     root_types Group::Root, Group::Federation, Group::Nejb
 
     private

--- a/app/models/jubla_group.rb
+++ b/app/models/jubla_group.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+# Superclass for Groups of the active branch of Jubla
+class JublaGroup < Group
+  # define active/global children
+  children Group::SimpleGroup
+end

--- a/app/models/nejb_group.rb
+++ b/app/models/nejb_group.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+# Superclass for Groups of the NEJB branch of Jubla
+class NejbGroup < Group
+  # define nejb/global children
+  children Group::NejbSimpleGroup
+end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -25,6 +25,7 @@ de:
         other: Regionen
       group/regional_board: Regionalleitung
       group/simple_group: Einfache Gruppe
+      group/nejb_simple_group: Einfache Gruppe
       group/state_agency: Arbeitsstelle
       group/alumnus_group:
         one: Ehemalige
@@ -289,6 +290,15 @@ de:
         other: Versandadresse
         long: Versandadresse Einfache Gruppe
 
+      group/nejb_simple_group/dispatch_address:
+        one: Versandadresse
+        other: Versandadresse
+        long: Versandadresse Einfache Gruppe
+
+      group/nejb_simple_group/group_admin: Adressverwaltung
+      group/nejb_simple_group/member: Mitglied
+      group/nejb_simple_group/external: Extern
+      group/nejb_simple_group/leader: Leitung
 
       census:
         one: Bestandesmeldungsperiode

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -73,8 +73,8 @@ describe Group do
       expect(subject.first).to eq(Group::Root)
     end
 
-    it "must have simple group as last item" do
-      expect(subject.last).to eq(Group::SimpleGroup)
+    it "must have NEJB simple group as last item" do
+      expect(subject.last).to eq(Group::NejbSimpleGroup)
     end
 
     context "#destroy" do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -53,7 +53,7 @@ describe Role do
     end
 
     it 'finishes with bottom most role' do
-      expect(subject.last).to eq(Group::SimpleGroup::DispatchAddress)
+      expect(subject.last).to eq(Group::NejbSimpleGroup::DispatchAddress)
     end
   end
 


### PR DESCRIPTION
fixes #131 

Existing `SimpleGroup`s need to be changed to the new type `NejbSimpleGroup` manually where needed.