### PR TITLE
Put the same columns in the union-statement

### DIFF
--- a/app/domain/jubla/mailing_lists/subscribers.rb
+++ b/app/domain/jubla/mailing_lists/subscribers.rb
@@ -26,7 +26,7 @@ module Jubla::MailingLists::Subscribers
 
   def excluded_by_contact_preference
     preference_column = "contactable_by_#{layer_type}"
-    return Person.select(:id).none unless Person.column_names.include?(preference_column)
+    return Person.none.select(:id) unless Person.column_names.include?(preference_column)
 
     Person.alumnus_only.where("#{preference_column}": false).select(:id)
   end

--- a/app/domain/jubla/mailing_lists/subscribers.rb
+++ b/app/domain/jubla/mailing_lists/subscribers.rb
@@ -26,7 +26,7 @@ module Jubla::MailingLists::Subscribers
 
   def excluded_by_contact_preference
     preference_column = "contactable_by_#{layer_type}"
-    return Person.none unless Person.column_names.include?(preference_column)
+    return Person.select(:id).none unless Person.column_names.include?(preference_column)
 
     Person.alumnus_only.where("#{preference_column}": false).select(:id)
   end


### PR DESCRIPTION
The generated SQL of `Person.none` includes all columns, by name. This method otherwise only returns a relation with an `id`-column. This PR harmonizes this and allows the UNION to be accepted by the DB-Server.

Fixes #158

Resolves Sentry-Issues:
- https://sentry.puzzle.ch/pitc/hitobito-backend/issues/72483
- https://sentry.puzzle.ch/pitc/hitobito-backend/issues/73178