### PR TITLE
Send mail for everyone leaving the layer

### DIFF
--- a/app/jobs/alumni_mail_job.rb
+++ b/app/jobs/alumni_mail_job.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2017-2024, Pfadibewegung Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -12,7 +12,7 @@ class AlumniMailJob < BaseJob
   end
 
   def perform
-    return if person.roles.without_alumnus.any?
+    return if person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).any?
 
     if group.is_a?(Group::Flock)
       AlumniMailer.new_member_flock(person).deliver_now
@@ -24,7 +24,7 @@ class AlumniMailJob < BaseJob
   private
 
   def group
-    Group.find(@group_id)
+    @group ||= Group.find(@group_id)
   end
 
   def person

--- a/app/jobs/alumni_mail_job.rb
+++ b/app/jobs/alumni_mail_job.rb
@@ -12,7 +12,7 @@ class AlumniMailJob < BaseJob
   end
 
   def perform
-    return if person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).any?
+    return if no_more_active_roles?
 
     if group.is_a?(Group::Flock)
       AlumniMailer.new_member_flock(person).deliver_now
@@ -22,6 +22,10 @@ class AlumniMailJob < BaseJob
   end
 
   private
+
+  def no_more_active_roles?
+    person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).any?
+  end
 
   def group
     @group ||= Group.find(@group_id)

--- a/spec/jobs/alumni_mail_job_spec.rb
+++ b/spec/jobs/alumni_mail_job_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -35,13 +35,25 @@ describe AlumniMailJob do
       expect { AlumniMailJob.new(group.id, person.id).perform }.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
 
-    it 'does not send email if there are other roles left' do
+    it 'does not send flock email if there are other roles in the current flock-layer left' do
       group = groups(:bern)
       person = Fabricate(Group::Flock::Leader.sti_name.to_sym, group: group).person
 
       expect(AlumniMailer).not_to receive(:new_member_flock).and_call_original
       expect(AlumniMailer).not_to receive(:new_member).and_call_original
       expect { AlumniMailJob.new(group.id, person.id).perform }.to change { ActionMailer::Base.deliveries.size }.by(0)
+    end
+
+    it 'sends flock email if there are other roles in other layers' do
+      group = groups(:bern)
+      other_group = groups(:muri)
+
+      role_class = Group::Flock::Leader.sti_name.to_sym
+
+      person = Fabricate(role_class, group: other_group).person
+
+      expect(AlumniMailer).to receive(:new_member_flock).with(person).and_call_original
+      expect { AlumniMailJob.new(group.id, person.id).perform }.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
   end
 


### PR DESCRIPTION
fixes #164 

Formerly, the mail was only sent if there were NO other roles. This might happen, but is not the current requirement. The mail should be sent whenever you leave the last leadership-role in the layer, regardless of other existing roles.