### PR TITLE
Add rake-tasks to handle existing 'Ehemalige'-groups

### DIFF
--- a/lib/tasks/nejb.rake
+++ b/lib/tasks/nejb.rake
@@ -25,6 +25,7 @@ namespace :nejb do
     end
   end
 
+  desc "Insert new root-group 'hitobito' to accomodate both Jubla and NEJB"
   task insert_new_root: [:abort_if_deactivated, :prepare, :environment] do
     admin_layer = nil
 
@@ -60,6 +61,59 @@ namespace :nejb do
     say_with_time "Regenerating ordering tables" do
       require Rails.root.join("db", "seeds", "support", "order_table_seeder")
       OrderTableSeeder.new.seed
+    end
+  end
+
+  namespace :flock_alumnus_groups do
+    desc "Merge duplicated Ehemalige-Groups to only have one (with this name) per Group"
+    task consolidate: [:abort_if_deactivated, :prepare, :environment] do
+      group_type = "Group::FlockAlumnusGroup"
+      group_name = "Ehemalige"
+      connection = ActiveRecord::Base.connection
+
+      # direct SQL to have detailed control over grouping
+      query = <<~SQL
+        SELECT parent_id, json_arrayagg(id ORDER BY id ASC) AS ids, count(*) AS count
+        FROM groups
+        WHERE name = '#{group_name}'
+          AND type = '#{group_type}'
+          AND deleted_at IS NULL
+          AND archived_at IS NULL
+        GROUP BY parent_id
+        ORDER BY count(*) DESC, parent_id ASC
+      SQL
+
+      say_with_time "Consolidating duplicated #{group_name}-groups" do
+        connection.select_rows(query).map do |parent_id, ids_json, count|
+          next if count == 1
+
+          ids = JSON.parse(ids_json)
+          first = ids.shift
+
+          new_group = ids.reduce(Group.find(first)) do |merged, id|
+            merger = Group::Merger.new(merged, Group.find(id), merged.name)
+            merger.merge!
+            merger.new_group
+          end
+
+          say "Consolidated #{count} groups into Group##{new_group.id}: #{new_group.name}", true
+
+          count
+        end.compact
+      end
+    end
+
+    desc "Rename 'Ehemalige' to 'Ausgetretene Leitungspersonen'"
+    task rename: [:abort_if_deactivated, :prepare, :environment] do
+      old_name = "Ehemalige"
+      new_name = "Ausgetretene Leitungspersonen"
+      the_type = "Group::FlockAlumnusGroup"
+
+      say_with_time "Renaming Alumnus-groups on flock-level" do
+        Group
+          .where(name: old_name, type: the_type, deleted_at: nil, archived_at: nil)
+          .update_all(name: new_name)
+      end
     end
   end
 end


### PR DESCRIPTION
This adds two new tasks:

- `nejb:flock_alumnus_groups:consolidate` to merge multiple "Ehemalige"-groups of the same name.
- `nejb:flock_alumnus_groups:rename` to rename "Ehemalige" to "Ausgetretenen Leitungspersonen", which explains the new process better

If an existing groups does have a new dedicated name, it will not be touched by either task. Archived and deleted one are also excempt on purpose.

This fixes #160 