### PR TITLE
Reduce alumnus management above flock

### DIFF
--- a/app/domain/jubla/role/alumnus_manager.rb
+++ b/app/domain/jubla/role/alumnus_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2021-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -55,7 +55,7 @@ module Jubla::Role
       person
         .roles
         .joins(:group)
-        .where(group: group, type: group.alumnus_class.name)
+        .where(group: group, type: group.alumnus_class.sti_name)
         .destroy_all
     end
 

--- a/app/domain/jubla/role/light_alumnus_manager.rb
+++ b/app/domain/jubla/role/light_alumnus_manager.rb
@@ -39,7 +39,7 @@ module Jubla::Role
       person
         .roles
         .joins(:group)
-        .where(group: group, type: group.alumnus_class.name)
+        .where(group: group, type: group.alumnus_class.sti_name)
         .destroy_all
     end
 

--- a/app/domain/jubla/role/light_alumnus_manager.rb
+++ b/app/domain/jubla/role/light_alumnus_manager.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2024, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+# Trimmed down version of the Jubla::Role::AlumnusManager
+#
+# This one only creates the "exiting"-role that can be filtered. It does not add
+# the person to the "former people"-group
+module Jubla::Role
+  class LightAlumnusManager
+    attr_reader :role, :group, :person
+
+    def initialize(role)
+      @role = role
+      @group = role.group
+      @person = role.person
+    end
+
+    def create
+      create_alumnus_role if last_in_group?
+    end
+
+    def destroy
+      destroy_alumnus_role
+    end
+
+    private
+
+    def create_alumnus_role
+      alumnus_role = group.alumnus_class.new(person: person, group: group)
+      alumnus_role.label = role.class.label
+      alumnus_role.save!
+    end
+
+    def destroy_alumnus_role
+      person
+        .roles
+        .joins(:group)
+        .where(group: group, type: group.alumnus_class.name)
+        .destroy_all
+    end
+
+    def last_in_group?
+      group.roles.where(person_id: person.id).empty?
+    end
+  end
+end

--- a/app/models/group/root.rb
+++ b/app/models/group/root.rb
@@ -13,10 +13,6 @@ class Group::Root < Group
     self.permissions = [:layer_and_below_full, :admin]
     self.two_factor_authentication_enforced = true
 
-    def skip_alumnus_callback
-      true
-    end
-
     def alumnus_manager
       @alumnus_manager ||= Jubla::Role::NullAlumnusManager.new
     end

--- a/app/models/jubla/role.rb
+++ b/app/models/jubla/role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito_jubla and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_jubla.
@@ -143,8 +143,10 @@ module Jubla::Role
   end
 
   def alumnus_manager
-    @alumnus_manager ||= Jubla::Role::AlumnusManager.new(
-      self, skip_alumnus_callback: skip_alumnus_callback
-    )
+    @alumnus_manager ||= if %w[Flock ChildGroup FlockAlumnusGroup].include? type.split("::", 3)[1]
+      Jubla::Role::AlumnusManager.new(self, skip_alumnus_callback: skip_alumnus_callback)
+    else
+      Jubla::Role::LightAlumnusManager.new(self)
+    end
   end
 end

--- a/app/models/nejb_role.rb
+++ b/app/models/nejb_role.rb
@@ -7,10 +7,6 @@
 
 class NejbRole < Role
   module AlumnusFreeRole
-    def skip_alumnus_callback
-      true
-    end
-
     def alumnus_manager
       @alumnus_manager ||= Jubla::Role::NullAlumnusManager.new
     end

--- a/spec/models/nejb_role_spec.rb
+++ b/spec/models/nejb_role_spec.rb
@@ -14,10 +14,6 @@ describe NejbRole do
     expect(subject).to be_a Jubla::Role
   end
 
-  it "disables the alumnus-callback" do
-    expect(subject.skip_alumnus_callback).to be_truthy
-  end
-
   it "uses the NullAlumnusManager" do
     expect(subject.alumnus_manager).to be_a Jubla::Role::NullAlumnusManager
   end


### PR DESCRIPTION
This introduces another alumunus-manager beside the "NullAlumnusManager". This codifies the reduce tasks in a more maintainable way.

Fixes #162 