### PR TITLE
Ignore archived alumni roles in cleanup (hitobito/hitobito_jubla#223)

### DIFF
--- a/app/domain/alumni.rb
+++ b/app/domain/alumni.rb
@@ -21,6 +21,6 @@ module Alumni
   ].freeze
 
   APPLICABLE_ROLE_TYPES = ::Role.all_types.reject do |role|
-    Alumni::EXCLUDED_ROLE_TYPES.select { |excluded| role < excluded }.any?
+    Alumni::EXCLUDED_ROLE_TYPES.any? { |excluded| role < excluded }
   end
 end

--- a/app/jobs/alumni_manager_job.rb
+++ b/app/jobs/alumni_manager_job.rb
@@ -25,7 +25,7 @@ class AlumniManagerJob < RecurringJob
 
   def destroy_obsolete
     active = Person.joins(:roles).merge(Role.where(type: APPLICABLE_ROLE_TYPES)).distinct
-    Role.alumnus_members.where(person_id: active).find_each do |role|
+    Role.alumnus_members.without_archived.where(person_id: active).find_each do |role|
       Jubla::Role::AlumnusManager.new(role).destroy
     end
   end


### PR DESCRIPTION
The AlumnusManager did not know anything about the archived feature, why it lead to exceptions when it tried to cleanup obsolete alumnus roles. Now, archived roles are igored during cleanup.

There could be other issues with archived roles, e.g. when creating an alumnus role, which we do not yet investigate.

Fixes https://github.com/hitobito/hitobito_jubla/issues/223