### PR TITLE
Check for active roles in same layer instead of destroying all alumnus roles when active role in any layer (hitobito/hitobito#3906)

### DIFF
--- a/app/jobs/alumni_manager_job.rb
+++ b/app/jobs/alumni_manager_job.rb
@@ -24,8 +24,9 @@ class AlumniManagerJob < RecurringJob
   end
 
   def destroy_obsolete
-    active = Person.joins(:roles).merge(Role.where(type: APPLICABLE_ROLE_TYPES)).distinct
-    Role.alumnus_members.without_archived.where(person_id: active).find_each do |role|
+    active_roles = Role.where(type: APPLICABLE_ROLE_TYPES).distinct
+    Role.alumnus_members.without_archived.where(person_id: active_roles.pluck(:person_id),
+      group_id: active_roles.pluck(:group_id)).find_each do |role|
       Jubla::Role::AlumnusManager.new(role).destroy
     end
   end

--- a/spec/jobs/alumni_manager_job_spec.rb
+++ b/spec/jobs/alumni_manager_job_spec.rb
@@ -36,6 +36,16 @@ describe AlumniManagerJob do
     expect { job.perform }.not_to change { person.roles.count }
   end
 
+  it "noops if alumni roles have been created and person has active role in different layer" do
+    role.update_columns(end_on: Date.yesterday)
+
+    Fabricate(Group::StateAgency::Leader.sti_name, group: groups(:be_agency), person: person)
+    Fabricate(Group::FederalAlumnusGroup::Member.sti_name, person: person, group: groups(:ch_ehemalige))
+    Fabricate(Group::FederalBoard::Alumnus.sti_name, person: person, group: groups(:federal_board))
+
+    expect { job.perform }.not_to change { person.reload.roles.pluck(:id) }
+  end
+
   it "deletes alumni roles if role becomes active" do
     role.update_columns(end_on: Date.yesterday)
 


### PR DESCRIPTION
fixes: https://github.com/hitobito/hitobito/issues/3906

The `AlumnusManagerJob` destroyed all Alumnus Roles every night when an active role existed in any other layer. 

Which then resulted in new alumni roles being created right after, since the person has ended or archived roles.