### PR TITLE
Nachname und Vorname bei Event-Anmeldungen nicht änderbar

### DIFF
--- a/app/helpers/event/participation_contact_datas_helper.rb
+++ b/app/helpers/event/participation_contact_datas_helper.rb
@@ -1,0 +1,16 @@
+#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+module Event::ParticipationContactDatasHelper
+  LOCKED_CONTACT_ATTRS = [:first_name, :last_name].freeze
+
+  def locked_contact_attr_options(attr, entry)
+    return {} unless LOCKED_CONTACT_ATTRS.include?(attr)
+    return {} unless entry.respond_to?(:person)
+    return {} unless entry.person.send(attr).present?
+
+    { readonly: true, help_inline: t('event.participation_contact_datas.fields.readonly_hint') }
+  end
+end

--- a/app/views/event/participation_contact_datas/_fields.html.haml
+++ b/app/views/event/participation_contact_datas/_fields.html.haml
@@ -1,0 +1,54 @@
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito_jubla and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_jubla.
+
+-# WAGON OVERRIDE: Zeile 9 ergänzt locked_contact_attr_options damit first_name/last_name
+-# readonly dargestellt werden wenn sie bereits im Profil befüllt sind.
+-# Sync prüfen bei Änderungen im Core:
+-# hitobito/app/views/event/participation_contact_datas/_fields.html.haml
+
+= field_set_tag do
+  - [:first_name, :last_name, :nickname, :company_name].each do |a|
+    - if event.show_contact_attr?(a)
+      = f.labeled_input_field(a, **locked_contact_attr_options(a, entry))
+
+= render 'event/participation_contact_datas/address_fields', f: f
+
+- if event.show_contact_attr?(:email)
+  = f.labeled_input_field :email, help_inline: ((entry.is_a? Event::Guest) ? '' : t('people.email_field.used_as_login')), class: 'd-inline '
+
+- if entry.is_a? Event::Guest
+  - unless event.hidden_contact_attrs.map(&:to_sym).include?(:phone_numbers)
+    = f.labeled_input_field(:phone_number, placeholder: PhoneNumber.human_attribute_name(:number))
+- else
+  - Event.possible_contact_associations.each do |a|
+    = field_set_tag do
+      - unless event.hidden_contact_attrs.map(&:to_sym).include?(a)
+        = f.labeled_inline_fields_for a, "contactable/#{a.to_s.singularize}_fields"
+
+  = field_set_tag do
+    - unless event.hidden_contact_attrs.map(&:to_sym).include?(:phone_numbers)
+      = f.labeled_inline_fields_for :phone_numbers, "contactable/phone_number_fields",
+                                    nil, event.required_contact_attr?(:phone_numbers)
+
+= field_set_tag do
+  - if event.show_contact_attr?(:gender)
+    = render 'people/gender_field', f: f, entry: entry
+
+  - if event.show_contact_attr?(:birthday)
+    = f.labeled_string_field(:birthday,
+                            value: f.date_value(:birthday),
+                            help_inline: t('people.fields.format_birthday'),
+                            class: 'col-2 d-inline')
+
+  = f.labeled_i18n_enum_field :language, Person.language_labels.to_a, class: 'form-select form-select-sm'
+
+- if entry.is_a?(Event::ParticipationContactData)
+  = field_set_tag do
+    - if entry.person != current_user
+      = hidden_field_tag(:person_id, entry.person.id)
+
+= render_extensions :fields, locals: { f: f }
+
+= render('people/privacy_policy_acceptance_field', policy_finder: @policy_finder, f: f, for_someone_else: entry.is_a?(Event::Guest))

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -16,6 +16,9 @@ de:
     export_enqueued: "Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen."
 
   event:
+    participation_contact_datas:
+      fields:
+        readonly_hint: "Kann nur im Profil geändert werden."
     camps:
       nav_left_camps:
         all_camps: Alle Lager

--- a/spec/helpers/event/participation_contact_datas_helper_spec.rb
+++ b/spec/helpers/event/participation_contact_datas_helper_spec.rb
@@ -1,0 +1,53 @@
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+require "spec_helper"
+
+describe Event::ParticipationContactDatasHelper, type: :helper do
+  describe "#locked_contact_attr_options" do
+    let(:person) { instance_double(Person, first_name: first_name, last_name: last_name) }
+    let(:entry) { instance_double(Event::ParticipationContactData, person: person) }
+    let(:first_name) { "Ada" }
+    let(:last_name) { "Lovelace" }
+
+    context "wenn first_name befüllt ist" do
+      it "gibt readonly und hint zurück" do
+        result = helper.locked_contact_attr_options(:first_name, entry)
+        expect(result[:readonly]).to be true
+        expect(result[:help_inline]).to be_present
+      end
+    end
+
+    context "wenn last_name befüllt ist" do
+      it "gibt readonly und hint zurück" do
+        result = helper.locked_contact_attr_options(:last_name, entry)
+        expect(result[:readonly]).to be true
+        expect(result[:help_inline]).to be_present
+      end
+    end
+
+    context "wenn first_name leer ist" do
+      let(:first_name) { nil }
+
+      it "gibt leere options zurück" do
+        expect(helper.locked_contact_attr_options(:first_name, entry)).to eq({})
+      end
+    end
+
+    context "für nicht gesperrte Felder (z.B. nickname)" do
+      it "gibt leere options zurück" do
+        expect(helper.locked_contact_attr_options(:nickname, entry)).to eq({})
+      end
+    end
+
+    context "für Event::Guest (kein person-Objekt)" do
+      let(:entry) { instance_double(Event::Guest) }
+
+      it "gibt leere options zurück ohne Fehler" do
+        expect(helper.locked_contact_attr_options(:first_name, entry)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Show first_name and last_name as readonly on participation contact form

When a person already has a first or last name in their profile, the fields are displayed as readonly during event registration. This prevents accidentally implying that the name can be changed per registration instead of in the profile.

A hint below the field informs the user where to change the data.

Dieser Commit wurde mit LLM-Unterstützung erstellt und kann vom Author nicht vollständig überprüft werden. Ich akzeptiere und bennene bewusst, die mögliche Zurückweisung/Ablehnung.

Warum View-Override und nicht Core-Änderung? Wir glauben, dass eine Anmeldung immer persönlich und daher ohne Anpassung des Vornnamen und Nachnamen erfolgen sollte. Wir könnten uns auch vorstellen, dass dies für alle Wagons sinnvoll wäre. Mein Vertrauen/Mut für einen Change im Core reicht nicht aus.

Es handelt sich NICHT un eine Sicherheitsmassnahme, sondern "nur" umd UX. Es gibt keine erverseitige Absicherung.

Der Helper-Spec testet die Logik, aber nicht ob das Partial tatsächlich korrekt gerendert wird.

Changes to be committed: new file:   app/helpers/event/participation_contact_datas_helper.rb new file:   app/views/event/participation_contact_datas/_fields.html.haml modified:   config/locales/views.de.yml new file:   spec/helpers/event/participation_contact_datas_helper_spec.rb