### PR TITLE
Feature/update social account labels

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,11 +50,6 @@ social_account:
     - E-Mail
     - --Pinterest
     - --X (Twitter)
-    - Facebook
-    - Instagram
-    - TikTok
-    - Webseite
-    - Andere
 
 role:
   # If a role last less than this number of days, it is not archived


### PR DESCRIPTION
Zusätzlich zu https://github.com/hitobito/hitobito/pull/4035 


Update social account predefined labels for jubla wagon

Angepasst an neue Core-Liste:

MSN, Skype, Twitter, Facebook, Webseite, Andere entfernt
(kommen neu direkt aus dem Core)
--Pinterest: wird aus Core-Liste ausgeschlossen
--X (Twitter): wird aus Core-Liste ausgeschlossen
E-Mail: jubla-spezifische Ergänzung bleibt