### PR TITLE
Simplify alumni processing (hitobito/hitobito#4105)

### DIFF
--- a/app/domain/jubla/role/alumnus_manager.rb
+++ b/app/domain/jubla/role/alumnus_manager.rb
@@ -17,16 +17,14 @@ module Jubla::Role
     end
 
     def create
-      create_alumnus_role if last_in_group?
+      Role.transaction do
+        role.update_columns(alumni_processed: true)
+        create_alumnus_role if last_in_group?
 
-      return if skip_alumnus_callback?
+        return if skip_alumnus_callback?
 
-      create_alumnus_group_member if last_in_layer? && person_old_enough?
-    end
-
-    def destroy
-      destroy_alumnus_role
-      destroy_alumnus_group_member
+        create_alumnus_group_member if last_in_layer? && person_old_enough?
+      end
     end
 
     private

--- a/app/domain/jubla/role/alumnus_manager.rb
+++ b/app/domain/jubla/role/alumnus_manager.rb
@@ -21,9 +21,9 @@ module Jubla::Role
         role.update_columns(alumni_processed: true)
         create_alumnus_role if last_in_group?
 
-        return if skip_alumnus_callback?
-
-        create_alumnus_group_member if last_in_layer? && person_old_enough?
+        if !skip_alumnus_callback? && last_in_layer? && person_old_enough?
+          create_alumnus_group_member
+        end
       end
     end
 

--- a/app/domain/jubla/role/light_alumnus_manager.rb
+++ b/app/domain/jubla/role/light_alumnus_manager.rb
@@ -20,11 +20,10 @@ module Jubla::Role
     end
 
     def create
-      create_alumnus_role if last_in_group?
-    end
-
-    def destroy
-      destroy_alumnus_role
+      Role.transaction do
+        role.update_columns(alumni_processed: true)
+        create_alumnus_role if last_in_group?
+      end
     end
 
     private

--- a/app/jobs/alumni_manager_job.rb
+++ b/app/jobs/alumni_manager_job.rb
@@ -11,23 +11,12 @@ class AlumniManagerJob < RecurringJob
   APPLICABLE_ROLE_TYPES = Alumni::APPLICABLE_ROLE_TYPES.map(&:sti_name)
 
   def perform_internal
-    destroy_obsolete
-    create_missing
-  end
+    scope = Role
+      .ended_or_archived
+      .where(type: APPLICABLE_ROLE_TYPES, alumni_processed: false)
 
-  def create_missing
-    alumni = Person.joins(:roles).merge(Role.alumnus_members).distinct
-    inactive = Role.ended_or_archived.where(type: APPLICABLE_ROLE_TYPES)
-    inactive.where.not(person_id: alumni).find_each do |role|
-      Jubla::Role::AlumnusManager.new(role).create
-    end
-  end
-
-  def destroy_obsolete
-    active_roles = Role.where(type: APPLICABLE_ROLE_TYPES).distinct
-    Role.alumnus_members.without_archived.where(person_id: active_roles.pluck(:person_id),
-      group_id: active_roles.pluck(:group_id)).find_each do |role|
-      Jubla::Role::AlumnusManager.new(role).destroy
+    scope.find_each do |role|
+      role.alumnus_manager.create
     end
   end
 

--- a/app/models/jubla/role.rb
+++ b/app/models/jubla/role.rb
@@ -19,11 +19,9 @@ module Jubla::Role
     after_save :set_person_origins
     after_destroy :set_person_origins
 
-    after_create :alumnus_manager_destroy
     after_destroy :alumnus_manager_create
 
-    after_create :alumnus_manager_create_for_alumnus, if: :alumnus_member?
-    after_destroy :alumnus_manager_destroy_for_alumnus, if: :alumnus_member?
+    after_update_commit :reset_alumni_processed, if: :alumni_processed?
   end
 
   module ClassMethods
@@ -118,6 +116,14 @@ module Jubla::Role
     roles_in_layer.without_alumnus
   end
 
+  def alumnus_manager
+    @alumnus_manager ||= if %w[Flock ChildGroup FlockAlumnusGroup].include? type.split("::", 3)[1]
+      Jubla::Role::AlumnusManager.new(self, skip_alumnus_callback: skip_alumnus_callback)
+    else
+      Jubla::Role::LightAlumnusManager.new(self)
+    end
+  end
+
   private
 
   def assert_no_active_roles
@@ -130,27 +136,11 @@ module Jubla::Role
     person.update_columns(GroupOriginator.new(person).to_h) # rubocop:disable Rails/SkipsModelValidations intentionally, because it's called from an after_save hook
   end
 
+  def reset_alumni_processed
+    update_columns(alumni_processed: false) unless end_on_was&.past?
+  end
+
   def alumnus_manager_create
     alumnus_manager.create if old_enough_to_soft_destroy? && alumnus_applicable?
-  end
-
-  def alumnus_manager_destroy
-    alumnus_manager.destroy unless group.alumnus? || alumnus_member?
-  end
-
-  def alumnus_manager_create_for_alumnus
-    alumnus_manager.create if roles_in_layer.alumnus_members.one?
-  end
-
-  def alumnus_manager_destroy_for_alumnus
-    alumnus_manager.destroy if roles_in_layer.alumnus_members.blank?
-  end
-
-  def alumnus_manager
-    @alumnus_manager ||= if %w[Flock ChildGroup FlockAlumnusGroup].include? type.split("::", 3)[1]
-      Jubla::Role::AlumnusManager.new(self, skip_alumnus_callback: skip_alumnus_callback)
-    else
-      Jubla::Role::LightAlumnusManager.new(self)
-    end
   end
 end

--- a/db/migrate/20260519131752_add_alumni_processed_to_roles.rb
+++ b/db/migrate/20260519131752_add_alumni_processed_to_roles.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026, Jubla. This file is part of
+# hitobito_pbs and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito_jubla.
+
+class AddAlumniProcessedToRoles < ActiveRecord::Migration[8.0]
+  def change
+    add_column(:roles, :alumni_processed, :boolean, default: false, null: false)
+  end
+end

--- a/spec/domain/jubla/role/alumnus_manager_spec.rb
+++ b/spec/domain/jubla/role/alumnus_manager_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+require "spec_helper"
+
+describe Jubla::Role::AlumnusManager do
+  let(:role) { roles(:flock_leader) }
+  let(:person) { role.person }
+
+  subject(:manager) { described_class.new(role) }
+
+  before do
+    role.update_columns(end_on: 1.day.ago)
+  end
+
+  it "changes role#alumni_processed and creates new alumnus role" do
+    expect do
+      manager.create
+    end.to change { role.reload.alumni_processed }.from(false).to(true)
+      .and change { person.reload.roles.select(&:alumnus_member?).count }.by(1)
+  end
+
+  context "with another active role in same group" do
+    it "changes role#alumni_processed and without creating new alumnus role" do
+      Fabricate(Group::Flock::President.to_s, group: groups(:innerroden), person:)
+
+      expect do
+        manager.create
+      end.to change { role.reload.alumni_processed }.from(false).to(true)
+        .and not_change { person.reload.roles.select(&:alumnus_member?).count }
+    end
+  end
+end

--- a/spec/domain/jubla/role/light_alumnus_manager_spec.rb
+++ b/spec/domain/jubla/role/light_alumnus_manager_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+require "spec_helper"
+
+describe Jubla::Role::LightAlumnusManager do
+  let(:role) { roles(:flock_leader) }
+  let(:person) { role.person }
+
+  subject(:manager) { described_class.new(role) }
+
+  before do
+    role.update_columns(end_on: 1.day.ago)
+  end
+
+  it "changes role#alumni_processed and creates new alumnus role" do
+    expect do
+      manager.create
+    end.to change { role.reload.alumni_processed }.from(false).to(true)
+      .and change { person.reload.roles.select(&:alumnus_member?).count }.by(1)
+  end
+
+  context "with another active role in same group" do
+    it "changes role#alumni_processed and without creating new alumnus role" do
+      Fabricate(Group::Flock::President.to_s, group: groups(:innerroden), person:)
+
+      expect do
+        manager.create
+      end.to change { role.reload.alumni_processed }.from(false).to(true)
+        .and not_change { person.reload.roles.select(&:alumnus_member?).count }
+    end
+  end
+end

--- a/spec/jobs/alumni_manager_job_spec.rb
+++ b/spec/jobs/alumni_manager_job_spec.rb
@@ -18,14 +18,14 @@ describe AlumniManagerJob do
   end
 
   it "noops if role expires in the future" do
-    role.update!(end_on: Time.zone.tomorrow)
-    expect { job.perform }.not_to change { person.roles.count }
+    role.update_columns(end_on: Time.zone.tomorrow)
+    expect { job.perform }.not_to change { person.reload.roles.count }
   end
 
   it "creates alumni role in group and layer if role expired" do
-    role.update!(end_on: Date.yesterday)
-    expect { job.perform }.to change { person.roles.count }.by(2)
-    expect(person.roles.map(&:type)).to match_array ["Group::FederalBoard::Alumnus", "Group::FederalAlumnusGroup::Member"]
+    role.update_columns(end_on: Date.yesterday)
+    expect { job.perform }.to change { person.reload.roles.count }.by(1)
+    expect(person.roles.map(&:type)).to match_array ["Group::FederalBoard::Alumnus"]
   end
 
   it "noops if alumni roles have been created" do
@@ -46,24 +46,4 @@ describe AlumniManagerJob do
     expect { job.perform }.not_to change { person.reload.roles.pluck(:id) }
   end
 
-  it "deletes alumni roles if role becomes active" do
-    role.update_columns(end_on: Date.yesterday)
-
-    Fabricate(Group::FederalAlumnusGroup::Member.sti_name, person: person, group: groups(:ch_ehemalige))
-    Fabricate(Group::FederalBoard::Alumnus.sti_name, person: person, group: groups(:federal_board))
-    role.update_columns(end_on: nil)
-
-    expect { job.perform }.to change { person.roles.count }.by(-2)
-    expect(person.roles.map(&:type)).to match_array ["Group::FederalBoard::Member"]
-  end
-
-  it "does not try to delete archived alumni roles if role becomes active" do
-    role.update_columns(end_on: Date.yesterday)
-    archived_alumnus_role = Fabricate(Group::FederalBoard::Alumnus.sti_name, person: person, group: groups(:federal_board), created_at: 2.years.ago, archived_at: 1.year.ago)
-    role.update_columns(end_on: nil)
-
-    expect { job.perform }.not_to change { person.roles.count }
-
-    expect(archived_alumnus_role.reload).to be_persisted
-  end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -65,6 +65,40 @@ describe Role do
     end
   end
 
+  context "#update" do
+    let(:role) { roles(:flock_leader) }
+
+    describe "alumni_processed" do
+      before do
+        role.update!(end_on: 1.day.ago, alumni_processed: true)
+      end
+
+      it "changes to false if new end_on is today" do
+        expect do
+          role.update!(end_on: Time.zone.today)
+        end.to change { role.reload.alumni_processed }.from(true).to(false)
+      end
+
+      it "changes to false if new end_on is in the future" do
+        expect do
+          role.update!(end_on: 1.week.from_now)
+        end.to change { role.reload.alumni_processed }.from(true).to(false)
+      end
+
+      it "changes to false if new end_on is blank" do
+        expect do
+          role.update!(end_on: nil)
+        end.to change { role.reload.alumni_processed }.from(true).to(false)
+      end
+
+      it "remains true if end_on changes to past value" do
+        expect do
+          role.update(end_on: 1.week.ago)
+        end.not_to change { role.reload.alumni_processed }
+      end
+    end
+  end
+
   context "alumnus group with AlumnusManager" do
     let(:group) { groups(:bern) }
     let(:alumni_group) { groups(:bern_ehemalige) }
@@ -92,17 +126,6 @@ describe Role do
 
     def alumnus_member_count
       Group::FlockAlumnusGroup::Member.where(group: alumni_group).count
-    end
-
-    context "create" do
-      create_samples.each do |role_type, group, change|
-        it "#{role_type} changes alumni members by #{change}" do
-          role = Fabricate(Group::FlockAlumnusGroup::Member.to_s, group: alumni_group)
-          expect do
-            Fabricate(role_type, person: role.person, group: groups(group))
-          end.to change { alumnus_member_count }.by(change.to_i)
-        end
-      end
     end
 
     context "destroy" do
@@ -133,38 +156,6 @@ describe Role do
         role = Fabricate(Group::Flock::Leader.sti_name, group: groups(:bern), created_at: some_time_ago)
         role.person.update(email: nil)
         expect { role.destroy }.not_to change { Delayed::Job.count }
-      end
-    end
-
-    context "after alumnus creation" do
-      it "create alumni member if new alumni role added" do
-        expect do
-          Fabricate("Group::Flock::Alumnus", group: groups(:bern))
-        end.to change { alumnus_member_count }.by(1)
-      end
-
-      it "only create one alumni member if multiple new alumni roles added in same layer" do
-        expect do
-          role = Fabricate("Group::Flock::Alumnus", group: groups(:bern))
-          Fabricate("Group::Flock::Alumnus", group: groups(:bern), person: role.person)
-        end.to change { alumnus_member_count }.by(1)
-      end
-    end
-
-    context "after alumnus deletion" do
-      it "destroies alumnus membership if last role" do
-        role = Fabricate("Group::Flock::Alumnus", group: groups(:bern))
-        expect do
-          role.destroy
-        end.to change { alumnus_member_count }.by(-1)
-      end
-
-      it "does nothing if there are some alumnus roles left in same layer" do
-        role = Fabricate("Group::Flock::Alumnus", group: groups(:bern))
-        Fabricate("Group::Flock::Alumnus", group: groups(:bern), person: role.person)
-        expect do
-          role.destroy
-        end.to change { alumnus_member_count }.by(0)
       end
     end
 
@@ -338,23 +329,6 @@ describe Role do
   context "alumnus role" do
     let(:role) { Fabricate(role_class.name.to_s, group: groups(:bern), created_at: some_time_ago) }
     let(:role_class) { Group::Flock::Leader }
-
-    context "create" do
-      it "creating active role flags alumnus role as deleted" do
-        role = Fabricate(Group::Flock::Alumnus.name, group: groups(:bern), created_at: some_time_ago)
-        expect do
-          Fabricate(Group::Flock::Leader.name, group: groups(:bern), person: role.person)
-        end.to change { Group::Flock::Alumnus.count }.by(-1)
-        expect(Role.with_inactive.find(role.id)).to be_present
-      end
-
-      it "creating alumnus role does not flag existing alumnus role as deleted" do
-        role = Fabricate(Group::Flock::Alumnus.name, group: groups(:bern), created_at: some_time_ago)
-        expect do
-          Fabricate(Group::Flock::Alumnus.name, group: groups(:bern), person: role.person)
-        end.to change { Group::Flock::Alumnus.count }.by(1)
-      end
-    end
 
     context "destroy" do
       it "recent role is flagged as deleted without creating alumnus role" do


### PR DESCRIPTION
- only handle creating of alumnus roles
- use manager consistently
- track processing status on role
- only operate on unprocessed roles
