### PR TITLE
NEJB: Ehemaligenverein (Schar) auf Ebene Kanton (Ehemalige)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8
 
+* Ehemaligenverein (Schar) kann direkt unter Kanton (Ehemalige) erstellt werden (hitobito_jubla#110)
 * Census Export wurde um Schar Art erweitert, gelöschte und archivierte Scharen werden ignoriert (hitobito_jubla#228)
 * Die globalen Event Fragen (schub, meisterwerk) wurden entfernt (hitobito_jubla#221)
 * Debitoren/Rechnungen für Schar-Kassier*in aktiviert (hitobito_jubla#237)

--- a/app/helpers/event/participation_contact_datas_helper.rb
+++ b/app/helpers/event/participation_contact_datas_helper.rb
@@ -1,0 +1,16 @@
+#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+module Event::ParticipationContactDatasHelper
+  LOCKED_CONTACT_ATTRS = [:first_name, :last_name].freeze
+
+  def locked_contact_attr_options(attr, entry)
+    return {} unless LOCKED_CONTACT_ATTRS.include?(attr)
+    return {} unless entry.respond_to?(:person)
+    return {} unless entry.person.send(attr).present?
+
+    { readonly: true, help_inline: t('event.participation_contact_datas.fields.readonly_hint') }
+  end
+end

--- a/app/models/group/nejb_kanton.rb
+++ b/app/models/group/nejb_kanton.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito_jubla.
 
 class Group::NejbKanton < NejbGroup
-  children Group::KantonEhemaligenverein, Group::NejbRegion
+  children Group::KantonEhemaligenverein, Group::NejbRegion, Group::NejbSchar
   self.layer = true
 
   class GroupAdmin < ::NejbRole

--- a/app/views/event/participation_contact_datas/_fields.html.haml
+++ b/app/views/event/participation_contact_datas/_fields.html.haml
@@ -1,0 +1,54 @@
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito_jubla and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_jubla.
+
+-# WAGON OVERRIDE: Zeile 9 ergänzt locked_contact_attr_options damit first_name/last_name
+-# readonly dargestellt werden wenn sie bereits im Profil befüllt sind.
+-# Sync prüfen bei Änderungen im Core:
+-# hitobito/app/views/event/participation_contact_datas/_fields.html.haml
+
+= field_set_tag do
+  - [:first_name, :last_name, :nickname, :company_name].each do |a|
+    - if event.show_contact_attr?(a)
+      = f.labeled_input_field(a, **locked_contact_attr_options(a, entry))
+
+= render 'event/participation_contact_datas/address_fields', f: f
+
+- if event.show_contact_attr?(:email)
+  = f.labeled_input_field :email, help_inline: ((entry.is_a? Event::Guest) ? '' : t('people.email_field.used_as_login')), class: 'd-inline '
+
+- if entry.is_a? Event::Guest
+  - unless event.hidden_contact_attrs.map(&:to_sym).include?(:phone_numbers)
+    = f.labeled_input_field(:phone_number, placeholder: PhoneNumber.human_attribute_name(:number))
+- else
+  - Event.possible_contact_associations.each do |a|
+    = field_set_tag do
+      - unless event.hidden_contact_attrs.map(&:to_sym).include?(a)
+        = f.labeled_inline_fields_for a, "contactable/#{a.to_s.singularize}_fields"
+
+  = field_set_tag do
+    - unless event.hidden_contact_attrs.map(&:to_sym).include?(:phone_numbers)
+      = f.labeled_inline_fields_for :phone_numbers, "contactable/phone_number_fields",
+                                    nil, event.required_contact_attr?(:phone_numbers)
+
+= field_set_tag do
+  - if event.show_contact_attr?(:gender)
+    = render 'people/gender_field', f: f, entry: entry
+
+  - if event.show_contact_attr?(:birthday)
+    = f.labeled_string_field(:birthday,
+                            value: f.date_value(:birthday),
+                            help_inline: t('people.fields.format_birthday'),
+                            class: 'col-2 d-inline')
+
+  = f.labeled_i18n_enum_field :language, Person.language_labels.to_a, class: 'form-select form-select-sm'
+
+- if entry.is_a?(Event::ParticipationContactData)
+  = field_set_tag do
+    - if entry.person != current_user
+      = hidden_field_tag(:person_id, entry.person.id)
+
+= render_extensions :fields, locals: { f: f }
+
+= render('people/privacy_policy_acceptance_field', policy_finder: @policy_finder, f: f, for_someone_else: entry.is_a?(Event::Guest))

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -16,6 +16,9 @@ de:
     export_enqueued: "Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen."
 
   event:
+    participation_contact_datas:
+      fields:
+        readonly_hint: "Kann nur im Profil geändert werden."
     camps:
       nav_left_camps:
         all_camps: Alle Lager

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -48,6 +48,8 @@ phone_number:
 social_account:
   predefined_labels:
     - E-Mail
+    - --Pinterest
+    - --X (Twitter)
     - Facebook
     - Instagram
     - TikTok

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,11 +50,6 @@ social_account:
     - E-Mail
     - --Pinterest
     - --X (Twitter)
-    - Facebook
-    - Instagram
-    - TikTok
-    - Webseite
-    - Andere
 
 role:
   # If a role last less than this number of days, it is not archived

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,9 +49,8 @@ social_account:
   predefined_labels:
     - E-Mail
     - Facebook
-    - MSN
-    - Skype
-    - Twitter
+    - Instagram
+    - TikTok
     - Webseite
     - Andere
 

--- a/spec/helpers/event/participation_contact_datas_helper_spec.rb
+++ b/spec/helpers/event/participation_contact_datas_helper_spec.rb
@@ -1,0 +1,53 @@
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_jubla.
+
+require "spec_helper"
+
+describe Event::ParticipationContactDatasHelper, type: :helper do
+  describe "#locked_contact_attr_options" do
+    let(:person) { instance_double(Person, first_name: first_name, last_name: last_name) }
+    let(:entry) { instance_double(Event::ParticipationContactData, person: person) }
+    let(:first_name) { "Ada" }
+    let(:last_name) { "Lovelace" }
+
+    context "wenn first_name befüllt ist" do
+      it "gibt readonly und hint zurück" do
+        result = helper.locked_contact_attr_options(:first_name, entry)
+        expect(result[:readonly]).to be true
+        expect(result[:help_inline]).to be_present
+      end
+    end
+
+    context "wenn last_name befüllt ist" do
+      it "gibt readonly und hint zurück" do
+        result = helper.locked_contact_attr_options(:last_name, entry)
+        expect(result[:readonly]).to be true
+        expect(result[:help_inline]).to be_present
+      end
+    end
+
+    context "wenn first_name leer ist" do
+      let(:first_name) { nil }
+
+      it "gibt leere options zurück" do
+        expect(helper.locked_contact_attr_options(:first_name, entry)).to eq({})
+      end
+    end
+
+    context "für nicht gesperrte Felder (z.B. nickname)" do
+      it "gibt leere options zurück" do
+        expect(helper.locked_contact_attr_options(:nickname, entry)).to eq({})
+      end
+    end
+
+    context "für Event::Guest (kein person-Objekt)" do
+      let(:entry) { instance_double(Event::Guest) }
+
+      it "gibt leere options zurück ohne Fehler" do
+        expect(helper.locked_contact_attr_options(:first_name, entry)).to eq({})
+      end
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -19,6 +19,13 @@ describe Group do
     its(:possible_children) { is_expected.to include(Group::SimpleGroup) }
   end
 
+  describe Group::NejbKanton do
+    subject { Group::NejbKanton }
+
+    it { is_expected.to have(4).possible_children }
+    its(:possible_children) { is_expected.to include(Group::NejbSchar) }
+  end
+
   describe Group::Flock do
     subject { Group::Flock }
 


### PR DESCRIPTION
Gerne möchten wir diese Änderung an Puzzle/Hitobito in die Verantwortung übergeben zur Eingliederungen in den regulären Release-Prozess. 


**Story**

Als Vorstand des NEJB (oder mit den erforderlichen Berechtigungen) möchte in der Ebene eines Kanton (Ehemalige) einen Ehemaligenverein (Schar) erstellen können.  (Gleiches Verhalten wie es möglich ist, eine Schar in der Ebene eines Kantons zu erstellen. 


Aktive Kollektivmitgliedschaft
Aktive Kollektivmitglieder sind als juristische Person konstituierte Ehemaligenvereinigungen, deren Zweck mit demjenigen von Netzwerk Ehemalige Jungwacht Blauring in den Grundzügen übereinstimmt. (Statuten NEJB)
Ehemaligenverein (Schar) kann Kollektivmitglied einer Region, (neu) Kanton oder direkt beim NEJB Mitglied sein. 


**Aspekte**

- Wir gehen davon aus, dass das erstellen von Ehemaligenverein (Schar) in der Ebene Kanton (Ehemalige) vergessen ging oder nicht angedacht war. Es ist aber so, dass dies erwünscht und notwendig ist. (Auf globaler Ebene soll weiterhin KEIN Ehemaligenverein (Schar) möglich sein)
- Fachsession BV1-26 / i.A. NEJB
- Bitte um Prüfung und sinngemässer Übernahme/Anpassung oder Vorschlag für alternativen


Demo in DEVELOPMENT
<img width="1900" height="737" alt="image" src="https://github.com/user-attachments/assets/1ff42a30-2763-4924-9e13-0b0d55022c7d" />



