### PR TITLE
NEJB: Ehemaligenverein (Schar) auf Ebene Kanton (Ehemalige)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8
 
+* Ehemaligenverein (Schar) kann direkt unter Kanton (Ehemalige) erstellt werden (hitobito_jubla#110)
 * Census Export wurde um Schar Art erweitert, gelöschte und archivierte Scharen werden ignoriert (hitobito_jubla#228)
 * Die globalen Event Fragen (schub, meisterwerk) wurden entfernt (hitobito_jubla#221)
 * Debitoren/Rechnungen für Schar-Kassier*in aktiviert (hitobito_jubla#237)

--- a/app/models/group/nejb_kanton.rb
+++ b/app/models/group/nejb_kanton.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito_jubla.
 
 class Group::NejbKanton < NejbGroup
-  children Group::KantonEhemaligenverein, Group::NejbRegion
+  children Group::KantonEhemaligenverein, Group::NejbRegion, Group::NejbSchar
   self.layer = true
 
   class GroupAdmin < ::NejbRole

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -19,6 +19,13 @@ describe Group do
     its(:possible_children) { is_expected.to include(Group::SimpleGroup) }
   end
 
+  describe Group::NejbKanton do
+    subject { Group::NejbKanton }
+
+    it { is_expected.to have(4).possible_children }
+    its(:possible_children) { is_expected.to include(Group::NejbSchar) }
+  end
+
   describe Group::Flock do
     subject { Group::Flock }
 


### PR DESCRIPTION
Gerne möchten wir diese Änderung an Puzzle/Hitobito in die Verantwortung übergeben zur Eingliederungen in den regulären Release-Prozess. 


**Story**

Als Vorstand des NEJB (oder mit den erforderlichen Berechtigungen) möchte in der Ebene eines Kanton (Ehemalige) einen Ehemaligenverein (Schar) erstellen können.  (Gleiches Verhalten wie es möglich ist, eine Schar in der Ebene eines Kantons zu erstellen. 


Aktive Kollektivmitgliedschaft
Aktive Kollektivmitglieder sind als juristische Person konstituierte Ehemaligenvereinigungen, deren Zweck mit demjenigen von Netzwerk Ehemalige Jungwacht Blauring in den Grundzügen übereinstimmt. (Statuten NEJB)
Ehemaligenverein (Schar) kann Kollektivmitglied einer Region, (neu) Kanton oder direkt beim NEJB Mitglied sein. 


**Aspekte**

- Wir gehen davon aus, dass das erstellen von Ehemaligenverein (Schar) in der Ebene Kanton (Ehemalige) vergessen ging oder nicht angedacht war. Es ist aber so, dass dies erwünscht und notwendig ist. (Auf globaler Ebene soll weiterhin KEIN Ehemaligenverein (Schar) möglich sein)
- Fachsession BV1-26 / i.A. NEJB
- Bitte um Prüfung und sinngemässer Übernahme/Anpassung oder Vorschlag für alternativen


Demo in DEVELOPMENT
<img width="1900" height="737" alt="image" src="https://github.com/user-attachments/assets/1ff42a30-2763-4924-9e13-0b0d55022c7d" />



