### PR TITLE
Fix alumni email notification bug (#4105)

### DIFF
--- a/app/domain/jubla/role/alumnus_manager.rb
+++ b/app/domain/jubla/role/alumnus_manager.rb
@@ -18,7 +18,7 @@ module Jubla::Role
 
     def create
       Role.transaction do
-        role.update_columns(alumni_processed: true)
+        Role.unscoped.where(id: role.id).update_all(alumni_processed: true)
         create_alumnus_role if last_in_group?
 
         if !skip_alumnus_callback? && last_in_layer? && person_old_enough?
@@ -39,9 +39,8 @@ module Jubla::Role
       return if alumnus_group.blank?
       return if alumnus_group_member_exists?
 
-      member = group.alumnus_member_class.new(person: person, group: alumnus_group)
-
-      enqueue_mail_job if member.save && person.email.present?
+      group.alumnus_member_class.new(person: person, group: alumnus_group).save!
+      enqueue_mail_job if person.email.present?
     end
 
     def alumnus_group_member_exists?
@@ -79,7 +78,9 @@ module Jubla::Role
     end
 
     def enqueue_mail_job
-      AlumniMailJob.new(alumnus_group.id, role.person.id).enqueue!(run_at: 1.day.from_now)
+      return unless group.layer_group.is_a?(Group::Flock)
+
+      AlumniMailJob.new(group.id, role.person.id).enqueue!(run_at: 1.day.from_now)
     end
 
     def alumnus_member_roles_in_layer

--- a/app/jobs/alumni_mail_job.rb
+++ b/app/jobs/alumni_mail_job.rb
@@ -12,16 +12,20 @@ class AlumniMailJob < BaseJob
   end
 
   def perform
-    return if no_more_active_roles_in_layer?
-    return unless group.layer_group.is_a?(Group::Flock)
+    return if active_roles_in_layer?
+    return if not_a_flock_group?
 
     AlumniMailer.new_member_flock(person).deliver_now
   end
 
   private
 
-  def no_more_active_roles_in_layer?
-    person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).any?
+  def not_a_flock_group?
+    !group.layer_group.is_a?(Group::Flock)
+  end
+
+  def active_roles_in_layer?
+    person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).exists?
   end
 
   def group

--- a/app/jobs/alumni_mail_job.rb
+++ b/app/jobs/alumni_mail_job.rb
@@ -12,15 +12,15 @@ class AlumniMailJob < BaseJob
   end
 
   def perform
-    return if no_more_active_roles?
-    return unless group.is_a?(Group::Flock)
+    return if no_more_active_roles_in_layer?
+    return unless group.layer_group.is_a?(Group::Flock)
 
     AlumniMailer.new_member_flock(person).deliver_now
   end
 
   private
 
-  def no_more_active_roles?
+  def no_more_active_roles_in_layer?
     person.roles.without_alumnus.roles_in_layer(person.id, group.layer_group_id).any?
   end
 

--- a/spec/domain/jubla/role/alumnus_manager_spec.rb
+++ b/spec/domain/jubla/role/alumnus_manager_spec.rb
@@ -34,4 +34,18 @@ describe Jubla::Role::AlumnusManager do
         .and not_change { person.reload.roles.select(&:alumnus_member?).count }
     end
   end
+
+  context "with another active role in same layer" do
+    it "changes role#alumni_processed but does not create alumnus group member" do
+      other_role = Fabricate(Group::FlockAlumnusGroup::Leader.sti_name, group: groups(:innerroden_ehemalige), person:)
+      expect(role.group.layer_group).to eq other_role.group.layer_group
+
+      expect do
+        manager.create
+      end.to change { role.reload.alumni_processed }.from(false).to(true)
+        .and not_change {
+               person.reload.roles.where("type LIKE '%::Member'").count
+             }
+    end
+  end
 end

--- a/spec/jobs/alumni_mail_job_spec.rb
+++ b/spec/jobs/alumni_mail_job_spec.rb
@@ -24,7 +24,7 @@ describe AlumniMailJob do
       expect { AlumniMailJob.new(group.id, person.id).perform }.to change { ActionMailer::Base.deliveries.size }.by(1)
     end
 
-    it "sends email if the group is not a flock" do
+    it "does not send email if the group is not a flock" do
       group = groups(:city)
       person = Fabricate(Group::RegionalAlumnusGroup::Member.sti_name.to_sym, group: group.alumnus_group).person
 
@@ -54,6 +54,19 @@ describe AlumniMailJob do
 
       expect(AlumniMailer).to receive(:new_member_flock).with(person).and_call_original
       expect { AlumniMailJob.new(group.id, person.id).perform }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    end
+
+    it "sends flock email for subgroup in flock layer" do
+      group = groups(:bern)
+      subgroup = Group::SimpleGroup.create!(parent: group, name: "Subgroup")
+      expect(subgroup.layer_group).to be_a(Group::Flock)
+
+      person = Fabricate(:person)
+
+      expect(AlumniMailer).to receive(:new_member_flock).with(person).and_call_original
+      expect { AlumniMailJob.new(subgroup.id, person.id).perform }.to change {
+        ActionMailer::Base.deliveries.size
+      }.by(1)
     end
   end
 end

--- a/spec/models/groups/alumnus_group_spec.rb
+++ b/spec/models/groups/alumnus_group_spec.rb
@@ -99,8 +99,8 @@ describe Group::AlumnusGroup do
 
       it "does not create job if saving new role fails" do
         expect_any_instance_of(AlumniMailJob).not_to receive(:enqueue!).and_call_original
-        allow_any_instance_of(Role).to receive(:save).and_return(false)
-        role.destroy
+        allow_any_instance_of(Role).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+        expect { role.destroy }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end


### PR DESCRIPTION
- Fix email not being sent: pass group.id instead of alumnus_group.id to AlumniMailJob
- Extend email sending to all groups within Flock layer_group (not just Flock groups)
- Use unscoped update_all for alumni_processed flag to handle hard-deleted roles
