### PR TITLE
Add symlinks to the core's AI agent setup

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+../hitobito/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ zeus.json
 
 # ignore Gemfile.lock for wagons
 Gemfile.lock
+Gemfile.local*
 
 .sass-cache
 .project

--- a/.opencode
+++ b/.opencode
@@ -1,0 +1,1 @@
+../hitobito/.opencode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+../hitobito/AGENTS_WAGON.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Links the AI agent instructions to the core, the same way `bin/wagon create` sets them up for new wagons and as already done in hitobito_pbs (eef269f8):

- `AGENTS.md` -> `../hitobito/AGENTS_WAGON.md`
- `CLAUDE.md` -> `AGENTS.md`
- `.claude` -> `../hitobito/.claude`
- `.opencode` -> `../hitobito/.opencode`

Also gitignores `Gemfile.local*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)