### PR TITLE
🤖 Migrate canton attribute to core Person (hitobito_oeku#12)

### DIFF
--- a/app/models/jubla/person.rb
+++ b/app/models/jubla/person.rb
@@ -28,8 +28,4 @@ module Jubla::Person
   def alumnus_only?
     self.class.alumnus_only.where(id: id).exists?
   end
-
-  def canton
-    self[:canton].presence || super
-  end
 end

--- a/app/views/people/_fields_jubla.html.haml
+++ b/app/views/people/_fields_jubla.html.haml
@@ -5,7 +5,6 @@
 
 = field_set_tag do
   = f.labeled_input_fields(:name_mother, :name_father)
-  = f.labeled_input_field(:canton, help_inline: t('.help_canton'))
 
 = field_set_tag do
   = f.labeled_input_fields(:nationality, :profession, :bank_account)

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -77,7 +77,6 @@ de:
     show_left_jubla:
       contactable_by: Kontaktfreigabe
     fields_jubla:
-      help_canton: Wird aus der PLZ berechnet falls leer.
       info_alumnus_contactable: "Mit dem Setzen eines Häkchens erlaubst du folgenden Ebenen, dich zu kontaktieren und dir Informationen zu senden:"
     show_event_jubla:
       coached: Meine Betreuungen

--- a/db/migrate/20140721071404_add_canton_to_person.rb
+++ b/db/migrate/20140721071404_add_canton_to_person.rb
@@ -7,7 +7,7 @@
 
 class AddCantonToPerson < ActiveRecord::Migration[4.2]
   def change
-    add_column(:people, :canton, :string)
+    add_column(:people, :canton, :string) unless column_exists?(:people, :canton)
     Person.reset_column_information
   end
 end

--- a/lib/hitobito_jubla/wagon.rb
+++ b/lib/hitobito_jubla/wagon.rb
@@ -86,7 +86,7 @@ module HitobitoJubla
 
       ### controllers
       PeopleController.permitted_attrs += [
-        :name_mother, :name_father, :nationality, :profession, :canton, :bank_account,
+        :name_mother, :name_father, :nationality, :profession, :bank_account,
         :j_s_number, :insurance_company, :insurance_number, :contactable_by_federation,
         :contactable_by_state, :contactable_by_region, :contactable_by_flock
       ]

--- a/spec/domain/bsv/info_spec.rb
+++ b/spec/domain/bsv/info_spec.rb
@@ -69,16 +69,10 @@ describe Bsv::Info do
   end
 
   it "#warnings.canton_count is set if any participant has missing canton" do
-    create_participant(zip_code: 3000)
+    create_participant(canton: "be")
     expect(info.warnings[:canton_count]).to eq(false)
 
     create_participant
-    expect(info.warnings[:canton_count]).to eq(true)
-    expect(info.error(:canton_count)).to eq "Nicht alle Teilnehmer haben einen gültigen Kanton gesetzt."
-  end
-
-  it "#warnings.canton_count is set if any participant has invalid 2 letter canton abbrevation" do
-    create_participant(canton: "Bern")
     expect(info.warnings[:canton_count]).to eq(true)
     expect(info.error(:canton_count)).to eq "Nicht alle Teilnehmer haben einen gültigen Kanton gesetzt."
   end

--- a/spec/domain/export/tabular/events/bsv_row_spec.rb
+++ b/spec/domain/export/tabular/events/bsv_row_spec.rb
@@ -115,11 +115,6 @@ describe Export::Tabular::Events::BsvRow do
         expect(info.canton_count).to eq 1
       end
 
-      it "ignores case when counting" do
-        create_participant_with_person_attrs(canton: "AG", birthday: birthday)
-        expect(info.canton_count).to eq 1
-      end
-
       it "ignores cantons on people outside of aged 17 to 30 group" do
         create_participant_with_person_attrs(canton: "ag", birthday: "31.12.1981")
         expect(info.canton_count).to eq 0

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -46,11 +46,6 @@ describe Person do
     end
   end
 
-  it "maps canton via location if zip_code is present" do
-    expect(Person.new(zip_code: 3000).canton).to eq "be"
-    expect(Person.new(zip_code: 3000, canton: "zh").canton).to eq("zh")
-  end
-
   context "alumnus_only" do
     it "does not find person without roles" do
       expect(Person.alumnus_only).not_to include(person)


### PR DESCRIPTION
## Summary
- Migrates jubla's own canton field to core's new `Person#canton`
- Guards the new `AddCantonToPeople` migration against core's own migration also adding the column on fresh installs
- Drops, then restores, the BSV `canton_count` "missing canton" warning (invalid cantons can no longer occur, but blank ones still can)

Refs https://github.com/hitobito/hitobito_oeku/issues/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)